### PR TITLE
feat(API): rename trigger->dispatch and search->observe

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/eq8-core.svg?maxAge=2592000)](https://npmjs.com/package/eq8-core) [![node](https://img.shields.io/node/v/eq8-core.svg?maxAge=2592000)](https://npmjs.com/package/eq8-core) [![David](https://img.shields.io/david/eq8/eq8-core.svg?maxAge=2592000)](https://david-dm.org/eq8/eq8-core) [![Travis](https://travis-ci.org/eq8/eq8-core.svg?branch=master)](https://travis-ci.org/eq8/eq8-core) [![codecov](https://codecov.io/gh/eq8/eq8-core/branch/master/graph/badge.svg)](https://codecov.io/gh/eq8/eq8-core)
 
-EQuateJS Core API Library - A loose implementation of [CQRS](http://martinfowler.com/bliki/CQRS.html)/[ES](http://martinfowler.com/eaaDev/EventSourcing.html) for managing application state.
+EQuateJS Core API Library - A loose interface for [CQRS](http://martinfowler.com/bliki/CQRS.html)/[ES](http://martinfowler.com/eaaDev/EventSourcing.html)
 
 ## Overview
 
@@ -21,16 +21,16 @@ The core API provides an ability to register handlers for events and queries, bu
 
 - [Installation](#installation)
 - [Events](#events)
-  - [Event: 'trigger'](#event-trigger)
-  - [Event: 'search'](#event-search)
+  - [Event: 'dispatch'](#event-dispatch)
+  - [Event: 'observe'](#event-observe)
   - [Event: 'listening'](#event-listening)
   - [Event: 'register:*registry*'](#event-registerregistry)
 - [Constructor](#constructor)
   - [Parameters](#parameters)
 - [Methods](#methods)
-  - [Core#trigger(e)](#coretriggere)
+  - [Core#dispatch(e, done)](#coredispatche-done)
     - [Parameters](#parameters-1)
-  - [Core#search(q, done)](#coresearchq-done)
+  - [Core#observe(q, done)](#coreobserveq-done)
     - [Parameters](#parameters-2)
   - [Core#listen(port, done)](#corelistenport-done)
     - [Parameters](#parameters-3)
@@ -54,13 +54,13 @@ npm install --save eq8-core
 
 Basically, `eq8-core` extends the [`EventEmitter`](https://nodejs.org/dist/latest-v4.x/docs/api/events.html#events_class_eventemitter) class and has the following events:
 
-### Event: 'trigger'
+### Event: 'dispatch'
 
-Emitted when `Core#trigger` gets called
+Emitted when `Core#dispatch` gets called
 
-### Event: 'search'
+### Event: 'observe'
 
-Emitted when `Core#search` gets called
+Emitted when `Core#observe` gets called
 
 ### Event: 'listening'
 
@@ -82,23 +82,23 @@ var api = new Core(options);
 - `options` is an optional object
   - `logger` is a `winston.Logger` options object
   - `on` is an object with the following properties:
-     - `trigger` is an array of `trigger` event listeners
-     - `search` is an array of `search` event listeners
+     - `dispatch` is an array of `dispatch` event listeners
+     - `observe` is an array of `observe` event listeners
      - `listening` is an array of `listening` event listeners
 
 ## Methods
 
-### Core#trigger(e)
+### Core#dispatch(e, done)
 
-Emits a `trigger` event and passes the parameters `e` and `done` to the event handler
+Emits a `dispatch` event and passes the parameters `e` and `done` to the event handler
 
 #### Parameters
 
 - `e` is an arbitrary object to represent a command event
 
-### Core#search(q, done)
+### Core#observe(q, done)
 
-Emits a `search` event and passes the parameters `q` and `done` to the event handler
+Emits a `observe` event and passes the parameters `q` and `done` to the event handler
 
 #### Parameters
 
@@ -135,15 +135,15 @@ function topOfStack(e, done, prior) {
   prior(e, done);
 }
 
-async.parallel([
+async.series([
   function(done) {
-    api.chainListener('trigger', bottomOfStack, done);
+    api.chainListener('dispatch', bottomOfStack, done);
   },
   function(done) {
-    api.chainListener('trigger', topOfStack, done); 
+    api.chainListener('dispatch', topOfStack, done); 
   }
-], function parallelDone() {
-  api.trigger('someEvent');
+], function seriesDone() {
+  api.dispatch('someEvent');
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The core API provides an ability to register handlers for events and queries, bu
 - [Installation](#installation)
 - [Events](#events)
   - [Event: 'dispatch'](#event-dispatch)
-  - [Event: 'observe'](#event-observe)
+  - [Event: 'subscribe'](#event-subscribe)
   - [Event: 'listening'](#event-listening)
   - [Event: 'register:*registry*'](#event-registerregistry)
 - [Constructor](#constructor)
@@ -30,7 +30,7 @@ The core API provides an ability to register handlers for events and queries, bu
 - [Methods](#methods)
   - [Core#dispatch(e, done)](#coredispatche-done)
     - [Parameters](#parameters-1)
-  - [Core#observe(q, done)](#coreobserveq-done)
+  - [Core#subscribe(q, done)](#coresubscribeq-done)
     - [Parameters](#parameters-2)
   - [Core#listen(port, done)](#corelistenport-done)
     - [Parameters](#parameters-3)
@@ -58,9 +58,9 @@ Basically, `eq8-core` extends the [`EventEmitter`](https://nodejs.org/dist/lates
 
 Emitted when `Core#dispatch` gets called
 
-### Event: 'observe'
+### Event: 'subscribe'
 
-Emitted when `Core#observe` gets called
+Emitted when `Core#subscribe` gets called
 
 ### Event: 'listening'
 
@@ -83,7 +83,7 @@ var api = new Core(options);
   - `logger` is a `winston.Logger` options object
   - `on` is an object with the following properties:
      - `dispatch` is an array of `dispatch` event listeners
-     - `observe` is an array of `observe` event listeners
+     - `subscribe` is an array of `subscribe` event listeners
      - `listening` is an array of `listening` event listeners
 
 ## Methods
@@ -96,9 +96,9 @@ Emits a `dispatch` event and passes the parameters `e` and `done` to the event h
 
 - `e` is an arbitrary object to represent a command event
 
-### Core#observe(q, done)
+### Core#subscribe(q, done)
 
-Emits a `observe` event and passes the parameters `q` and `done` to the event handler
+Emits a `subscribe` event and passes the parameters `q` and `done` to the event handler
 
 #### Parameters
 

--- a/lib/api/dispatch.js
+++ b/lib/api/dispatch.js
@@ -7,9 +7,9 @@
 'use strict';
 
 module.exports = function exported() {
-	return function search(q, done) {
+	return function dispatch(e, done) {
 		var api = this;
 
-		api.emit('search', q, done);
+		api.emit('dispatch', e, done);
 	};
 };

--- a/lib/api/observe.js
+++ b/lib/api/observe.js
@@ -7,9 +7,9 @@
 'use strict';
 
 module.exports = function exported() {
-	return function trigger(e) {
+	return function observe(q, done) {
 		var api = this;
 
-		api.emit('trigger', e);
+		api.emit('observe', q, done);
 	};
 };

--- a/lib/api/subscribe.js
+++ b/lib/api/subscribe.js
@@ -7,9 +7,9 @@
 'use strict';
 
 module.exports = function exported() {
-	return function observe(q, done) {
+	return function subscribe(q, done) {
 		var api = this;
 
-		api.emit('observe', q, done);
+		api.emit('subscribe', q, done);
 	};
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ function Api(options) {
 			]
 		},
 		on: {
-			observe: [],
+			subscribe: [],
 			dispatch: [],
 			listening: [],
 			initialized: []
@@ -78,8 +78,8 @@ function _resumeInit(api, options, error) {
 	var addDispatchHooks = _.bind(api.chainListener, api, 'dispatch');
 	_.each(options.on.dispatch, addDispatchHooks);
 
-	var addObserveHooks = _.bind(api.chainListener, api, 'observe');
-	_.each(options.on.observe, addObserveHooks);
+	var addSubscribeHooks = _.bind(api.chainListener, api, 'subscribe');
+	_.each(options.on.subscribe, addSubscribeHooks);
 
 	var addInitHooks = _.bind(api.chainListener, api, 'initialized');
 	_.each(options.on.initialized, addInitHooks);
@@ -102,7 +102,7 @@ Api.prototype.register = require('./api/register')(_, async);
 
 Api.prototype.dispatch = require('./api/dispatch')();
 
-Api.prototype.observe = require('./api/observe')(_);
+Api.prototype.subscribe = require('./api/subscribe')(_);
 
 Api.prototype.listen = require('./api/listen')(_);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,8 +45,8 @@ function Api(options) {
 			]
 		},
 		on: {
-			search: [],
-			trigger: [],
+			observe: [],
+			dispatch: [],
 			listening: [],
 			initialized: []
 		}
@@ -75,11 +75,11 @@ function _resumeInit(api, options, error) {
 	api.chainListener('initialized', initialized);
 
 	// CUSTOM LISTENERS
-	var addTriggerHooks = _.bind(api.chainListener, api, 'trigger');
-	_.each(options.on.trigger, addTriggerHooks);
+	var addDispatchHooks = _.bind(api.chainListener, api, 'dispatch');
+	_.each(options.on.dispatch, addDispatchHooks);
 
-	var addSearchHooks = _.bind(api.chainListener, api, 'search');
-	_.each(options.on.search, addSearchHooks);
+	var addObserveHooks = _.bind(api.chainListener, api, 'observe');
+	_.each(options.on.observe, addObserveHooks);
 
 	var addInitHooks = _.bind(api.chainListener, api, 'initialized');
 	_.each(options.on.initialized, addInitHooks);
@@ -100,9 +100,9 @@ Api.prototype.addRegistrar = require('./api/add-registrar')(_, async);
 
 Api.prototype.register = require('./api/register')(_, async);
 
-Api.prototype.trigger = require('./api/trigger')();
+Api.prototype.dispatch = require('./api/dispatch')();
 
-Api.prototype.search = require('./api/search')(_);
+Api.prototype.observe = require('./api/observe')(_);
 
 Api.prototype.listen = require('./api/listen')(_);
 

--- a/test/test.index.js
+++ b/test/test.index.js
@@ -4,38 +4,38 @@ var test = require('tape');
 var proxyquire = require('proxyquire');
 var Core = require('../index.js');
 
-// add-registrar.js  chain-listener.js  listen.js	register.js  search.js	trigger.js
+// add-registrar.js  chain-listener.js  listen.js	register.js  observe.js	dispatch.js
 
 test('test lib/index', function(t) {
 	t.plan(1);
 	t.ok(true, 'placeholder');
 });
 
-test('Core#trigger', function(t) {
+test('Core#dispatch', function(t) {
 	var core = new Core();
 	var fixtureAction = 'someArbitraryAction';
 
 	t.plan(1);
-	core.on('trigger', function(e) {
+	core.on('dispatch', function(e) {
 		t.equal(e, fixtureAction);
 	});
 
-	core.trigger(fixtureAction);
+	core.dispatch(fixtureAction);
 });
 
-test('Core#search', function(t) {
+test('Core#observe', function(t) {
 	var core = new Core();
 	var fixtureQuery = 'someArbitraryQuery';
 	var fixtureError = 'someArbitraryError';
 	var fixtureResult = 'someArbitraryResult';
 
 	t.plan(3);
-	core.on('search', function(q, done) {
+	core.on('observe', function(q, done) {
 		t.equal(q, fixtureQuery);
 		done(fixtureError, fixtureResult);
 	});
 
-	core.search(fixtureQuery, function(err, result) {
+	core.observe(fixtureQuery, function(err, result) {
 		t.equal(err, fixtureError);
 		t.equal(result, fixtureResult);
 	});

--- a/test/test.index.js
+++ b/test/test.index.js
@@ -4,7 +4,7 @@ var test = require('tape');
 var proxyquire = require('proxyquire');
 var Core = require('../index.js');
 
-// add-registrar.js  chain-listener.js  listen.js	register.js  observe.js	dispatch.js
+// add-registrar.js  chain-listener.js  listen.js	register.js  subscribe.js	dispatch.js
 
 test('test lib/index', function(t) {
 	t.plan(1);
@@ -23,19 +23,19 @@ test('Core#dispatch', function(t) {
 	core.dispatch(fixtureAction);
 });
 
-test('Core#observe', function(t) {
+test('Core#subscribe', function(t) {
 	var core = new Core();
 	var fixtureQuery = 'someArbitraryQuery';
 	var fixtureError = 'someArbitraryError';
 	var fixtureResult = 'someArbitraryResult';
 
 	t.plan(3);
-	core.on('observe', function(q, done) {
+	core.on('subscribe', function(q, done) {
 		t.equal(q, fixtureQuery);
 		done(fixtureError, fixtureResult);
 	});
 
-	core.observe(fixtureQuery, function(err, result) {
+	core.subscribe(fixtureQuery, function(err, result) {
 		t.equal(err, fixtureError);
 		t.equal(result, fixtureResult);
 	});


### PR DESCRIPTION
`Core#dispatch` accepts a callback function as a second argument too.

BREAKING CHANGE: `Core#trigger` and `Core#search` has been replaced. See README.md